### PR TITLE
Support backwards jump in LCG CLI

### DIFF
--- a/HelloWorldApp.sln
+++ b/HelloWorldApp.sln
@@ -7,7 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldApp", "HelloWorld
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinearCongruentGenerator", "LinearCongruentGenerator\LinearCongruentGenerator.csproj", "{B757D739-0577-42C8-9115-EABBDDB6C273}"
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinearCongruentGenerator.Tests", "LinearCongruentGenerator.Tests\LinearCongruentGenerator.Tests.csproj", "{38E7B90B-7901-4358-9B34-B87483812686}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,5 +26,9 @@ Global
 		{B757D739-0577-42C8-9115-EABBDDB6C273}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B757D739-0577-42C8-9115-EABBDDB6C273}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B757D739-0577-42C8-9115-EABBDDB6C273}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38E7B90B-7901-4358-9B34-B87483812686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38E7B90B-7901-4358-9B34-B87483812686}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38E7B90B-7901-4358-9B34-B87483812686}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38E7B90B-7901-4358-9B34-B87483812686}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/HelloWorldApp/Program.cs
+++ b/HelloWorldApp/Program.cs
@@ -86,7 +86,7 @@ if (interactive)
             case "help":
                 Console.WriteLine("Commands:");
                 Console.WriteLine("  short                 - output next number");
-                Console.WriteLine("  fast <n>              - jump ahead n steps and output next number");
+                Console.WriteLine("  fast <n>              - move n steps (backwards if n<0) and show resulting seed");
                 Console.WriteLine("  set m|a|c <value>     - set multiplier/addition/modulus");
                 Console.WriteLine("  get m|a|c             - get current multiplier/addition/modulus");
                 Console.WriteLine("  seed <value>          - set seed value");
@@ -104,8 +104,15 @@ if (interactive)
                     Console.WriteLine("Usage: fast <steps>");
                     break;
                 }
-                rng.Jump(steps);
-                Console.WriteLine(rng.Next());
+                if (steps == 0)
+                {
+                    Console.WriteLine(rng.Seed);
+                }
+                else
+                {
+                    rng.Jump(steps);
+                    Console.WriteLine(rng.Seed);
+                }
                 break;
 
             case "set":
@@ -152,7 +159,7 @@ if (interactive)
                         Console.WriteLine(modulus);
                         break;
                     case "seed":
-                        Console.WriteLine(seed);
+                        Console.WriteLine(rng.Seed);
                         break;
                     default:
                         Console.WriteLine("Unknown parameter. Use m, a, c or seed.");

--- a/LinearCongruentGenerator.Tests/LCGRandomizerTests.cs
+++ b/LinearCongruentGenerator.Tests/LCGRandomizerTests.cs
@@ -1,0 +1,27 @@
+using LinearCongruentGenerator;
+using System.Collections.Generic;
+using Xunit;
+
+namespace LinearCongruentGenerator.Tests;
+
+public class LCGRandomizerTests
+{
+    [Fact]
+    public void JumpForwardAndBackward()
+    {
+        long m = 1103515245;
+        long a = 12345;
+        long c = 1L << 31;
+        var rng1 = new LCGRandomizer(m, a, c, 1);
+        var values = new List<long>();
+        for (int i = 0; i < 5; i++)
+            values.Add(rng1.Next());
+
+        var rng2 = new LCGRandomizer(m, a, c, 1);
+        rng2.Jump(5);
+        Assert.Equal(rng1.Seed, rng2.Seed);
+
+        rng2.Jump(-1);
+        Assert.Equal(values[3], rng2.Seed);
+    }
+}

--- a/LinearCongruentGenerator.Tests/LinearCongruentGenerator.Tests.csproj
+++ b/LinearCongruentGenerator.Tests/LinearCongruentGenerator.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LinearCongruentGenerator\LinearCongruentGenerator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/LinearCongruentGenerator/LCGRandomizer.cs
+++ b/LinearCongruentGenerator/LCGRandomizer.cs
@@ -19,6 +19,11 @@ public class LCGRandomizer
     }
 
     /// <summary>
+    /// Gets the current seed value without advancing the generator.
+    /// </summary>
+    public long Seed => _seed;
+
+    /// <summary>
     /// Returns the next random number in the sequence.
     /// </summary>
     public long Next()
@@ -36,17 +41,36 @@ public class LCGRandomizer
     }
 
     /// <summary>
-    /// Jumps ahead by the specified number of iterations using a fast method.
+    /// Jumps by the specified number of iterations using a fast method. Negative
+    /// values move backwards.
     /// </summary>
     public void Jump(long jumps)
     {
-        if (jumps <= 0)
+        if (jumps == 0)
             return;
+
+        bool backwards = jumps < 0;
+        if (backwards)
+            jumps = -jumps;
 
         long accMul = 1;
         long accAdd = 0;
-        long curMul = _multiplier;
-        long curAdd = _addition;
+
+        long curMul;
+        long curAdd;
+
+        if (backwards)
+        {
+            long invMul = ModInverse(_multiplier, _modulus);
+            curMul = invMul;
+            curAdd = Mod(-_addition * invMul, _modulus);
+        }
+        else
+        {
+            curMul = _multiplier;
+            curAdd = _addition;
+        }
+
         long step = jumps;
 
         while (step > 0)
@@ -63,6 +87,27 @@ public class LCGRandomizer
         }
 
         _seed = Mod(accMul * _seed + accAdd, _modulus);
+    }
+
+    private long ModInverse(long value, long modulus)
+    {
+        long t = 0, newT = 1;
+        long r = modulus, newR = Mod(value, modulus);
+
+        while (newR != 0)
+        {
+            long q = r / newR;
+            (t, newT) = (newT, t - q * newT);
+            (r, newR) = (newR, r - q * newR);
+        }
+
+        if (r > 1)
+            throw new ArgumentException("Value is not invertible.");
+
+        if (t < 0)
+            t += modulus;
+
+        return t;
     }
 
     private static long Mod(long value, long modulus)


### PR DESCRIPTION
## Summary
- expose current seed on `LCGRandomizer`
- allow `Jump` to move backwards
- add seed-display logic and new `fast` semantics in CLI
- add xUnit tests for bidirectional jumping

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68435ac97368832c93cf4fa9ad55ac9e