### PR TITLE
Add extra tests for LCG logic

### DIFF
--- a/LinearCongruentGenerator.Tests/LCGRandomizerTests.cs
+++ b/LinearCongruentGenerator.Tests/LCGRandomizerTests.cs
@@ -24,4 +24,39 @@ public class LCGRandomizerTests
         rng2.Jump(-1);
         Assert.Equal(values[3], rng2.Seed);
     }
+
+    [Fact]
+    public void JumpNegativeValues_MoveBackwards()
+    {
+        long m = 1103515245;
+        long a = 12345;
+        long c = 1L << 31;
+
+        var rng1 = new LCGRandomizer(m, a, c, 1);
+        var values = new List<long>();
+        for (int i = 0; i < 7; i++)
+            values.Add(rng1.Next());
+
+        var rng2 = new LCGRandomizer(m, a, c, 1);
+        rng2.Jump(7);
+        rng2.Jump(-3);
+
+        Assert.Equal(values[3], rng2.Seed);
+    }
+
+    [Fact]
+    public void SetSeed_ResetsSequence()
+    {
+        long m = 1103515245;
+        long a = 12345;
+        long c = 1L << 31;
+
+        var rng1 = new LCGRandomizer(m, a, c, 1);
+        rng1.SetSeed(10);
+
+        var rng2 = new LCGRandomizer(m, a, c, 10);
+
+        for (int i = 0; i < 5; i++)
+            Assert.Equal(rng2.Next(), rng1.Next());
+    }
 }

--- a/LinearCongruentGenerator.Tests/LCGValidatorBoundaryTests.cs
+++ b/LinearCongruentGenerator.Tests/LCGValidatorBoundaryTests.cs
@@ -1,0 +1,31 @@
+using LinearCongruentGenerator;
+using Xunit;
+
+namespace LinearCongruentGenerator.Tests;
+
+public class LCGValidatorBoundaryTests
+{
+    [Theory]
+    [InlineData(5, 1, 5)]
+    [InlineData(6, 1, 5)]
+    public void MultiplierAtLeastModulus_Throws(long m, long a, long c)
+    {
+        Assert.Throws<InvalidMultiplierException>(() => LCGValidator.Validate(m, a, c));
+    }
+
+    [Theory]
+    [InlineData(1, 5, 5)]
+    [InlineData(1, 6, 5)]
+    public void AdditionAtLeastModulus_Throws(long m, long a, long c)
+    {
+        Assert.Throws<InvalidAdditionException>(() => LCGValidator.Validate(m, a, c));
+    }
+
+    [Theory]
+    [InlineData(1, 0, 0)]
+    [InlineData(1, 0, -5)]
+    public void ModulusNonPositive_Throws(long m, long a, long c)
+    {
+        Assert.Throws<InvalidModulusException>(() => LCGValidator.Validate(m, a, c));
+    }
+}


### PR DESCRIPTION
## Summary
- extend LCGRandomizerTests with negative jump and SetSeed tests
- add LCGValidatorBoundaryTests for parameter boundary cases

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_684364e3ce74832ca89d95ca0d2737ed