### PR TITLE
Add CRand cross-validation tests

### DIFF
--- a/LinearCongruentGenerator.Tests/CRandComparisonTests.cs
+++ b/LinearCongruentGenerator.Tests/CRandComparisonTests.cs
@@ -1,0 +1,25 @@
+using LinearCongruentGenerator;
+using Xunit;
+
+namespace LinearCongruentGenerator.Tests;
+
+public class CRandComparisonTests
+{
+    private static long CRand(ref long seed)
+    {
+        seed = unchecked(1103515245 * seed + 12345) & 0x7fffffff;
+        return seed;
+    }
+
+    [Fact]
+    public void MatchesCRandSequence()
+    {
+        long seed = 1;
+        var rng = new LCGRandomizer(1103515245, 12345, 1L << 31, seed);
+        for (int i = 0; i < 10; i++)
+        {
+            long expected = CRand(ref seed);
+            Assert.Equal(expected, rng.Next());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add cross-validation test comparing `LCGRandomizer` with C's `rand()` algorithm

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet run --project LinearCongruentGenerator.CLI`
- `dotnet test HelloWorldApp.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6843709852e0832c8dd9e2949cc86cbe