### PR TITLE
Improve CLI warnings

### DIFF
--- a/LinearCongruentGenerator.Tests/LCGValidatorTests.cs
+++ b/LinearCongruentGenerator.Tests/LCGValidatorTests.cs
@@ -28,4 +28,12 @@ public class LCGValidatorTests
     {
         Assert.Throws<InvalidModulusException>(() => LCGValidator.Validate(m, a, c));
     }
+
+    [Fact]
+    public void AnsiParametersWithSmallModulus_Throws()
+    {
+        long multiplier = 1103515245;
+        long addition = 12345;
+        Assert.Throws<InvalidMultiplierException>(() => LCGValidator.Validate(multiplier, addition, 5));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ seed <val>       # set the seed value
 exit             # quit the CLI
 ```
 
+If a supplied parameter is invalid when using the `set` command, the CLI
+displays a warning in yellow. The previous valid value is shown so you can
+manually restore it with another `set` command. Until a valid value is
+provided, the generator is not rebuilt and its output may no longer be
+reliable.
+
 ## Running tests
 
 After a successful build, execute the test suite with:


### PR DESCRIPTION
## Summary
- rename `RebuildRng` to `BuildRng` and invoke it from the constructor
- keep invalid parameters and show previous values in yellow warnings
- document manual reversion and risks in README
- add test for invalid modulus using ANSI parameters

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68436d8b34b8832c8c76fb266164771f