### PR TITLE
Handle non-invertible fast jumps in CLI

### DIFF
--- a/LinearCongruentGenerator.CLI/CommandHandler.cs
+++ b/LinearCongruentGenerator.CLI/CommandHandler.cs
@@ -62,8 +62,18 @@ public class CommandHandler
                 }
                 else
                 {
-                    _rng.Jump(steps);
-                    Console.WriteLine(_rng.Seed);
+                    try
+                    {
+                        _rng.Jump(steps);
+                        Console.WriteLine(_rng.Seed);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine($"Warning: {ex.Message}. Negative jumps require the multiplier and modulus to be relatively prime.");
+                        Console.WriteLine("The jump was not performed.");
+                        Console.ResetColor();
+                    }
                 }
                 return true;
 


### PR DESCRIPTION
## Summary
- catch `ArgumentException` when performing negative jumps in the CLI
- display a yellow warning explaining the issue and keep the app running

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`
- `dotnet run --project LinearCongruentGenerator.CLI`

------
https://chatgpt.com/codex/tasks/task_e_684373fc7b48832c991028b1149ffe8d