### PR TITLE
Update artifact step

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,28 @@
+name: .NET CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    - name: Build
+      run: dotnet build HelloWorldApp.sln
+    - name: Test
+      run: dotnet test HelloWorldApp.sln --verbosity normal
+    - name: Publish for Windows
+      run: dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+    - name: Upload Windows executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: lcg-cli-win-x64
+        path: LinearCongruentGenerator.CLI/bin/Release/net8.0/win-x64/publish/

--- a/README.md
+++ b/README.md
@@ -63,3 +63,13 @@ After a successful build, execute the test suite with:
 ```bash
 dotnet test HelloWorldApp.sln --verbosity normal
 ```
+
+## Publishing a single Windows executable
+
+To generate a single Windows `.exe` without additional files, run:
+
+```bash
+dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+```
+
+The executable is written to `LinearCongruentGenerator.CLI/bin/Release/net8.0/win-x64/publish/`.


### PR DESCRIPTION
## Summary
- fix workflow failure by using `actions/upload-artifact@v4`
- publish Windows executable as a single file
- document how to publish an `.exe`

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68437430587c832cad9f326f8a6dc18b