### PR TITLE
Add release instructions and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build
+        run: dotnet build HelloWorldApp.sln --configuration Release
+      - name: Publish
+        run: dotnet publish LinearCongruentGenerator.CLI -c Release -o published
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app
+          path: published

--- a/LinearCongruentGenerator/LinearCongruentGenerator.csproj
+++ b/LinearCongruentGenerator/LinearCongruentGenerator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -73,3 +73,28 @@ dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 --self-contain
 ```
 
 The executable is written to `LinearCongruentGenerator.CLI/bin/Release/net8.0/win-x64/publish/`.
+
+## Creating Releases
+
+1. Update the version in `LinearCongruentGenerator/LinearCongruentGenerator.csproj`.
+2. Commit the change and create a git tag:
+
+```bash
+git tag -a v1.0.0 -m "Release v1.0.0"
+```
+
+3. Push your tag to GitHub and draft a new release in the web interface.
+
+## Packaging for NuGet
+
+Use `dotnet pack` to create a NuGet package from the library project:
+
+```bash
+dotnet pack LinearCongruentGenerator/LinearCongruentGenerator.csproj --configuration Release
+```
+
+The generated `.nupkg` is found in `LinearCongruentGenerator/bin/Release`.
+
+## Deployment with GitHub Actions
+
+An example workflow is provided in `.github/workflows/deploy.yml`. It builds the solution and publishes the CLI whenever a tag starting with `v` is pushed.


### PR DESCRIPTION
## Summary
- bump library version to 1.0.0
- document how to create releases and packages
- add GitHub Actions workflow for tag deployments

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`
- `dotnet pack LinearCongruentGenerator/LinearCongruentGenerator.csproj --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68437943a2f0832cb9672fa8126e411b