### PR TITLE
Add AOT publish instructions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build
+        run: dotnet build HelloWorldApp.sln --configuration Release
+      - name: Pack library
+        run: dotnet pack LinearCongruentGenerator/LinearCongruentGenerator.csproj --configuration Release
+      - name: Push package to GitHub Packages
+        run: |
+          dotnet nuget push LinearCongruentGenerator/bin/Release/*.nupkg \
+            --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json \
+            --api-key ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish
+        run: |
+          dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=true \
+            -p:PublishAot=true \
+            -o published
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app
+          path: published

--- a/LinearCongruentGenerator/LinearCongruentGenerator.csproj
+++ b/LinearCongruentGenerator/LinearCongruentGenerator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,77 @@ dotnet test HelloWorldApp.sln --verbosity normal
 To generate a single Windows `.exe` without additional files, run:
 
 ```bash
-dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+dotnet publish LinearCongruentGenerator.CLI -c Release -r win-x64 \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -p:PublishTrimmed=true \
+  -p:PublishAot=true
 ```
 
 The executable is written to `LinearCongruentGenerator.CLI/bin/Release/net8.0/win-x64/publish/`.
+
+Using `PublishTrimmed` removes unused framework code while `PublishAot` compiles
+the project ahead-of-time to a native image. These options considerably reduce
+the final file size at the cost of longer build times.
+
+## Creating Releases
+
+1. Update the version in `LinearCongruentGenerator/LinearCongruentGenerator.csproj`.
+2. Commit the change and create a git tag:
+
+```bash
+git tag -a v1.0.0 -m "Release v1.0.0"
+git push origin v1.0.0
+```
+
+3. Draft a new release on GitHub using the pushed tag.
+
+## Packaging for NuGet
+
+Use `dotnet pack` to create a NuGet package from the library project:
+
+```bash
+dotnet pack LinearCongruentGenerator/LinearCongruentGenerator.csproj --configuration Release
+```
+
+The generated `.nupkg` is found in `LinearCongruentGenerator/bin/Release`.
+
+Running `dotnet pack` does **not** publish the package. You must push the
+`.nupkg` file to a registry to make it available.
+
+### Publishing to NuGet.org
+
+Publish the package to the public NuGet feed using an API key from nuget.org:
+
+```bash
+dotnet nuget push LinearCongruentGenerator/bin/Release/*.nupkg \
+  --source https://api.nuget.org/v3/index.json --api-key <NUGET_API_KEY>
+```
+
+Once uploaded you can reference it in other projects:
+
+```bash
+dotnet add package LinearCongruentGenerator --version 1.0.0
+```
+
+Replace the version number with the published version.
+
+### Publishing to GitHub Packages
+
+Authenticate to GitHub Packages and push the package with the `dotnet` CLI:
+
+```bash
+dotnet nuget add source --username <USER> --password <TOKEN> \
+  --store-password-in-clear-text --name github \
+  "https://nuget.pkg.github.com/<OWNER>/index.json"
+dotnet nuget push LinearCongruentGenerator/bin/Release/*.nupkg \
+  --source github --api-key <TOKEN>
+```
+
+Replace `<USER>`, `<TOKEN>` and `<OWNER>` with your account details. In GitHub
+Actions you can use `${{ secrets.GITHUB_TOKEN }}` instead of a personal access
+token.
+
+## Deployment with GitHub Actions
+
+An example workflow is provided in `.github/workflows/deploy.yml`. It builds the solution and publishes the CLI whenever a tag starting with `v` is pushed.


### PR DESCRIPTION
## Summary
- explain trimming and AOT when publishing single-file exe
- clarify that `dotnet pack` only creates the package and show how to push to nuget.org
- build trimmed+AOT executable in the deploy workflow

## Testing
- `dotnet build HelloWorldApp.sln`
- `dotnet test HelloWorldApp.sln --verbosity normal`
- `dotnet pack LinearCongruentGenerator/LinearCongruentGenerator.csproj --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68437943a2f0832cb9672fa8126e411b